### PR TITLE
compile things statically for better packaging

### DIFF
--- a/cgc_configure_afl_debug
+++ b/cgc_configure_afl_debug
@@ -2,4 +2,4 @@
 
 ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DAFL -g3 -ggdb -gdwarf-4' --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DAFL -g3 -ggdb -gdwarf-4' --python=`which python2` --static

--- a/cgc_configure_afl_opt
+++ b/cgc_configure_afl_opt
@@ -4,4 +4,4 @@
 
 CFLAGS="-O3" ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --extra-cflags='-DAFL' --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --extra-cflags='-DAFL' --python=`which python2` --static

--- a/cgc_configure_debug
+++ b/cgc_configure_debug
@@ -2,4 +2,4 @@
 
 ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DDEBUG_MMAP -DDEBUG_STACK -DDEBUG_SIGNAL -g3 -ggdb -gdwarf-4' --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DDEBUG_MMAP -DDEBUG_STACK -DDEBUG_SIGNAL -g3 -ggdb -gdwarf-4' --python=`which python2` --static

--- a/cgc_configure_nxtracer_debug
+++ b/cgc_configure_nxtracer_debug
@@ -2,4 +2,4 @@
 
 ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DENFORCE_NX -DTRACER -g3 -ggdb -gdwarf-4' --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DENFORCE_NX -DTRACER -g3 -ggdb -gdwarf-4' --python=`which python2` --static

--- a/cgc_configure_nxtracer_opt
+++ b/cgc_configure_nxtracer_opt
@@ -4,4 +4,4 @@
 
 CFLAGS="-O3" ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --extra-cflags='-DENFORCE_NX -DTRACER' --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --extra-cflags='-DENFORCE_NX -DTRACER' --python=`which python2` --static

--- a/cgc_configure_opt
+++ b/cgc_configure_opt
@@ -4,4 +4,4 @@
 
 CFLAGS="-O3" ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --python=`which python2` --static

--- a/cgc_configure_tracer_debug
+++ b/cgc_configure_tracer_debug
@@ -2,4 +2,4 @@
 
 ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DTRACER -g3 -ggdb -gdwarf-4' --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --enable-debug --disable-werror --extra-cflags='-DTRACER -g3 -ggdb -gdwarf-4' --python=`which python2` --static

--- a/cgc_configure_tracer_opt
+++ b/cgc_configure_tracer_opt
@@ -4,4 +4,4 @@
 
 CFLAGS="-O3" ./configure \
     --disable-tools --disable-netmap --disable-spice --disable-curl --disable-virtfs --disable-qom-cast-debug --disable-vde --disable-libnfs --disable-libiscsi --disable-curses --disable-fdt --disable-rbd --disable-opengl --disable-lzo --disable-usb-redir --disable-xfsctl --disable-snappy --disable-bzip2 --disable-guest-agent --disable-glusterfs --disable-vte --disable-vhdx --disable-libssh2 --disable-quorum --disable-tpm --disable-smartcard-nss --disable-libusb --disable-vhost-scsi --disable-vhost-net --disable-docs --disable-zlib-test --disable-bluez --disable-brlapi --disable-kvm \
-    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --extra-cflags='-DTRACER' --python=`which python2`
+    --disable-system --enable-linux-user --enable-guest-base --disable-gtk --disable-sdl --disable-vnc --target-list=i386-linux-user --disable-werror --extra-cflags='-DTRACER' --python=`which python2` --static


### PR DESCRIPTION
We are trying to compile shellphish-qemu statically. For consistency, we want to do the same for qemu-cgc.
I manually checked all of the targets can be compiled correctly except for the two afl ones that requries a patch that I don't have.